### PR TITLE
Update Host_IO-Win.cpp

### DIFF
--- a/source/Host_IO-Win.cpp
+++ b/source/Host_IO-Win.cpp
@@ -554,7 +554,7 @@ bool Host_IO::GetNextChild ( Host_IO::FolderRef folder, std::string* childName )
 	if ( folder == Host_IO::noFolderRef ) return false;
 
 	do {	// Ignore all children with names starting in '.'. This covers ., .., .DS_Store, etc.
-		found = (bool) FindNextFile ( folder, &childInfo );
+		found = (bool) FindNextFile ( folder, (LPWIN32_FIND_DATAA) &childInfo );
 	} while ( found && (childInfo.cFileName[0] == '.') );
 	if ( ! found ) return false;
 


### PR DESCRIPTION
Host_IO-Win.cpp:557:66: error: cannot convert 'WIN32_FIND_DATAW*' to 'LPWIN32_FIND_DATAA' {aka '_WIN32_FIND_DATAA*'}
  557 |   found = (bool) FindNextFile ( folder, /*(LPWIN32_FIND_DATAA)*/ &childInfo );
      |                                                                  ^~~~~~~~~~
      |                                                                  |
      |                                                                  WIN32_FIND_DATAW*