### PR TITLE
Update OS_Utils_WIN.cpp

### DIFF
--- a/XMPFiles/source/PluginHandler/OS_Utils_WIN.cpp
+++ b/XMPFiles/source/PluginHandler/OS_Utils_WIN.cpp
@@ -22,7 +22,7 @@ OS_ModuleRef LoadModule( const std::string & inModulePath, bool inOnlyResourceAc
 	ToUTF16 ( (UTF8Unit*)inModulePath.c_str(), inModulePath.size() + 1, &wideString, false ); // need +1 character otherwise \0 won't be converted into UTF16
 
 	DWORD flags = inOnlyResourceAccess ? LOAD_LIBRARY_AS_IMAGE_RESOURCE : 0;
-	OS_ModuleRef result = ::LoadLibraryEx((WCHAR*) wideString.c_str(), NULL, flags);
+	OS_ModuleRef result = ::LoadLibraryEx((LPCSTR) wideString.c_str(), NULL, flags);
 
 	// anything below indicates error in LoadLibrary
 	if((result != NULL) && (result < OS_ModuleRef(32)))


### PR DESCRIPTION
OS_Utils_WIN.cpp:25:40: error: cannot convert 'WCHAR*' {aka 'wchar_t*'} to 'LPCSTR' {aka 'const char*'}
   25 |  OS_ModuleRef result = ::LoadLibraryEx((WCHAR*) wideString.c_str(), NULL, flags);
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                        |
      |                                        WCHAR* {aka wchar_t*}