### PR TITLE
Improve linux gcc version check

### DIFF
--- a/build/shared/SharedConfig_Common.cmake
+++ b/build/shared/SharedConfig_Common.cmake
@@ -75,8 +75,8 @@ endfunction(SetupInternalBuildDirectory)
 function(SetupCompilerFlags)
 	if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
 	    set(OUTPUT_VARIABLE "")
-		# Execute GCC with the -dumpversion option, to give us a version string
-		execute_process(COMMAND ${CMAKE_CXX_COMPILER} "-dumpversion" OUTPUT_VARIABLE GCC_VERSION_STRING)
+		# Execute GCC with the --version option, to give us a version string
+		execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--version" OUTPUT_VARIABLE GCC_VERSION_STRING)
 	
 		# Match only the major and minor versions of the version string
 		string(REGEX MATCH "[0-9]+.[0-9]+.[0-9]" GCC_MAJOR_MINOR_VERSION_STRING "${GCC_VERSION_STRING}")


### PR DESCRIPTION
I tried to build this library for Linux and Windows to add it to our Node wrapper https://github.com/Lambda-IT/xmp-toolkit.
During the Linux build process I hit the same issue as mentioned here: https://github.com/adobe/XMP-Toolkit-SDK/issues/8.
I fixed it with the --version flag instead of the -dumpversion flag which includes only the major version.

In my case (I built it on Debian-WSL) I had also to set the GCC_VERSION_STRING variable.
I used for this also the --version output from gcc.
May this is a thing you have to document in the programmers guide PDF.