### PR TITLE
Remove bogus loop

### DIFF
--- a/XMPCore/source/XMPUtils.cpp
+++ b/XMPCore/source/XMPUtils.cpp
@@ -3345,7 +3345,6 @@ XMPUtils::SetTimeZone ( XMP_DateTime * xmpTime )
 		ansi_localtime ( &now, &tmLocal );
 	} else {
 		tmLocal.tm_year = xmpTime->year - 1900;
-		while ( tmLocal.tm_year < 70 ) tmLocal.tm_year += 4;	// ! Some versions of mktime barf on years before 1970.
 		tmLocal.tm_mon	 = xmpTime->month - 1;
 		tmLocal.tm_mday	 = xmpTime->day;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This loop can run for millions of iterations if `xmpTime->year` is a negative number like -2147483648. According to the comment, this loop is a defense against bad implementations of `mktime`. I'm skeptical that `mktime` can't handle years before 1970, but if that's really true then this loop should be replaced with `MAX(tmLocal.tm_year, 70)`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
