### PR TITLE
Linux ARM  builds no longer use the `-m64` flag which isn't supported

### DIFF
--- a/build/ProductConfig.cmake
+++ b/build/ProductConfig.cmake
@@ -114,8 +114,12 @@ if (UNIX)
 			endif()
 
 			if(CMAKE_CL_64)
-				set(XMP_EXTRA_COMPILE_FLAGS "-m64")
-				set(XMP_EXTRA_LINK_FLAGS "-m64")
+
+				if(NOT ${CMAKE_ARCH} MATCHES "ARM64")
+					set(XMP_EXTRA_COMPILE_FLAGS "-m64")
+					set(XMP_EXTRA_LINK_FLAGS "-m64")
+				endif()
+
 				if(CENTOS)	
 					set(XMP_PLATFORM_FOLDER "i80386linux_x64_centos") # add XMP_BUILDMODE_DIR to follow what other platforms do
 					set(XMP_GCC_LIBPATH /opt/llvm/lib)
@@ -136,8 +140,11 @@ if (UNIX)
 		else()
 			# running toolchain
 			if(CMAKE_CL_64)
-				set(XMP_EXTRA_COMPILE_FLAGS "-m64")
-				set(XMP_EXTRA_LINK_FLAGS "-m64")
+
+				if(NOT ${CMAKE_ARCH} MATCHES "ARM64")
+					set(XMP_EXTRA_COMPILE_FLAGS "-m64")
+					set(XMP_EXTRA_LINK_FLAGS "-m64")
+				endif()
 				
 				if(CENTOS)	
 					set(XMP_GCC_LIBPATH /opt/llvm/lib)


### PR DESCRIPTION
## Description

Previously when compiling under these architectures, `gcc` would complain that the `-m64` flag does not exist

## Related Issue

https://github.com/adobe/XMP-Toolkit-SDK/issues/81


## Motivation and Context

Currently you cannot build on Linux ARM based systems.

## How Has This Been Tested?

After making this change I was able to initiate a build without getting the `gcc` error.

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
