### PR TITLE
Fix -Wnontrivial-memcall warning

### DIFF
--- a/XMPFiles/source/FormatSupport/PSIR_Support.hpp
+++ b/XMPFiles/source/FormatSupport/PSIR_Support.hpp
@@ -286,7 +286,7 @@ public:
 		{
 			// ! Gag! Transfer ownership of the dataPtr and rsrcName!
 			this->FreeData();
-			memcpy ( this, &in, sizeof(*this) );	// AUDIT: Use of sizeof(InternalRsrcInfo) is safe.
+			memcpy ( static_cast<void*>(this), &in, sizeof(*this) );	// AUDIT: Use of sizeof(InternalRsrcInfo) is safe.
 			*((void**)&in.dataPtr) = 0;		// The pointer is now owned by "this".
 			*((void**)&in.rsrcName) = 0;	// The pointer is now owned by "this".
 		};

--- a/XMPFiles/source/FormatSupport/TIFF_Support.hpp
+++ b/XMPFiles/source/FormatSupport/TIFF_Support.hpp
@@ -938,7 +938,7 @@ private:
 		{
 			// ! Gag! Transfer ownership of the dataPtr!
 			this->FreeData();
-			memcpy ( this, &in, sizeof(*this) );	// AUDIT: Use of sizeof(InternalTagInfo) is safe.
+			memcpy ( static_cast<void*>(this), &in, sizeof(*this) );	// AUDIT: Use of sizeof(InternalTagInfo) is safe.
 			if ( this->dataLen <= 4 ) {
 				this->dataPtr = (XMP_Uns8*) &this->smallValue;	// Don't use the copied pointer.
 			} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Memcall functions work at the byte level so they don't know about C++semantics and these C++ objects might not have trivial constructors or destructors. Clang has started complaining about this with this warning (-Wnontrivial-memcall). I silenced the warning by explicitly casting the pointer to void* with static_cast. I did this fix because it seems the code developer knows the consequences with using memcall functions with C++ objects.

external/XMP-Toolkit-SDK/XMPFiles/source/FormatSupport/TIFF_Support.hpp:941:13: error: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'TIFF_FileWriter::InternalTagInfo'
[-Werror,-Wnontrivial-memcall]
  941 |                         memcpy ( this, &in, sizeof(*this) );
// AUDIT: Use of sizeof(InternalTagInfo) is safe.
      |                                  ^

external/XMP-Toolkit-SDK/XMPFiles/source/FormatSupport/PSIR_Support.hpp:289:13: error: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'PSIR_FileWriter::InternalRsrcInfo'
[-Werror,-Wnontrivial-memcall]
  289 |                         memcpy ( this, &in, sizeof(*this) );
// AUDIT: Use of sizeof(InternalRsrcInfo) is safe.
      |                                  ^

## Related Issue

https://github.com/adobe/XMP-Toolkit-SDK/issues/111

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

I built this repo with the change in Android and warnings disappear.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
