### PR TITLE
Fix iOS build issues with the XMP plugin's module utils

### DIFF
--- a/XMPFiles/source/PluginHandler/ModuleUtils.h
+++ b/XMPFiles/source/PluginHandler/ModuleUtils.h
@@ -18,6 +18,10 @@ typedef HMODULE OS_ModuleRef;
 #include <CoreFoundation/CFBundle.h>
 #include <memory>
 typedef CFBundleRef OS_ModuleRef;
+#elif XMP_iOSBuild
+#include <CoreFoundation/CFBundle.h>
+#include <memory>
+typedef CFBundleRef OS_ModuleRef;
 #elif XMP_UNIXBuild
 # if __clang__
 #include <memory>


### PR DESCRIPTION
## Description

I'm adding iOS build support for xmp-toolkit-rs. This code is absolutely necessary for xmp-toolkit-rs to build successfully on iOS. See [this PR](https://github.com/adobe/xmp-toolkit-rs/pull/278) for details. I have tested and confirmed that the build is working correctly on the iOS app.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
